### PR TITLE
chore: make dev script work without Docker

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "docker compose up --build",
+    "dev": "npm run dev:backend & npm run dev:frontend & wait",
+    "dev:docker": "docker compose up --build",
     "dev:frontend": "npm run dev --workspace=packages/frontend",
     "dev:backend": "npm run dev --workspace=packages/backend",
     "lint": "biome check . && markdownlint-cli2 '**/*.md'",


### PR DESCRIPTION
## Summary

- Changed `npm run dev` to run backend and frontend directly via Node.js (`& wait` pattern) instead of `docker compose up --build`
- Added `npm run dev:docker` for the full containerised stack when explicitly needed
- Enables development inside the autonomous agent container (which has no Docker installed)

## Test plan

- [ ] `npm run dev` starts both backend and frontend without Docker (Ctrl+C kills both)
- [ ] `npm run dev:docker` still starts the full Docker stack
- [ ] Inside the autonomous agent container, `npm run dev` works with DATABASE_URL set

🤖 Generated with [Claude Code](https://claude.com/claude-code)