### PR TITLE
fix: resolve agent entrypoint auth and remote failures

### DIFF
--- a/autonomous/scripts/agent-entrypoint.sh
+++ b/autonomous/scripts/agent-entrypoint.sh
@@ -36,6 +36,9 @@ rm -rf /workspace/{*,.[!.]*}
 echo "Cloning ${REPO_URL} (branch: ${BASE_BRANCH:-main})..."
 gh repo clone "${REPO_URL}" . -- --branch "${BASE_BRANCH:-main}"
 
+# Configure git to use gh for HTTPS authentication (enables git push)
+gh auth setup-git
+
 # ---------------------------------------------------------------------------
 # Step 1b: Configure remotes
 # ---------------------------------------------------------------------------
@@ -43,7 +46,11 @@ STEP="remotes"
 UPSTREAM_REPO="${UPSTREAM_REPO:-}"
 if [ -n "${UPSTREAM_REPO}" ]; then
     echo "Adding upstream remote: ${UPSTREAM_REPO}..."
-    git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+    if git remote get-url upstream &>/dev/null; then
+        git remote set-url upstream "https://github.com/${UPSTREAM_REPO}.git"
+    else
+        git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
+    fi
     git fetch upstream main
 fi
 


### PR DESCRIPTION
## Summary
- **Upstream remote already exists**: `gh repo clone` automatically creates an `upstream` remote when cloning a fork, so `git remote add upstream` fails. Now checks if the remote exists first and uses `set-url` to update it.
- **git push auth failure**: Raw `git` commands don't pick up `GITHUB_TOKEN` automatically. Added `gh auth setup-git` after clone to configure git's credential helper.

## Test plan
- [ ] Run `./autonomous/start.sh --logs` and verify the agent starts without exit code 3 or 128
- [ ] Verify the agent successfully pushes its working branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)