### PR TITLE
fix: use pre-installed gitleaks binary in agent container

### DIFF
--- a/autonomous/scripts/.pre-commit-config.yaml
+++ b/autonomous/scripts/.pre-commit-config.yaml
@@ -10,7 +10,10 @@ repos:
       - id: check-yaml
       - id: no-commit-to-branch
         args: ['--branch', 'main']
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.24.3
+  - repo: local
     hooks:
       - id: gitleaks
+        name: gitleaks
+        entry: gitleaks git --pre-commit --redact --staged --verbose
+        language: system
+        pass_filenames: false


### PR DESCRIPTION
## Summary
- The gitleaks pre-commit hook was configured to fetch from the remote GitHub repo, which tries to download Go and compile gitleaks at commit time
- This fails inside the agent container after the firewall locks down outbound access (step 3 in entrypoint)
- Switched to a `local` hook with `language: system` so it uses the gitleaks binary already installed in the Docker image at `/usr/local/bin/gitleaks`

## Test plan
- [ ] Rebuild agent container and verify `gitleaks` is on PATH
- [ ] Run a commit inside the container after firewall is active — should pass without network errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)