### PR TITLE
fix: remove nested transaction in dbmate migration

### DIFF
--- a/db/migrations/20260304000001_create_updated_at_trigger.sql
+++ b/db/migrations/20260304000001_create_updated_at_trigger.sql
@@ -1,6 +1,4 @@
 -- migrate:up
-BEGIN;
-
 CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -9,11 +7,5 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
-
 DROP FUNCTION IF EXISTS update_updated_at_column();
-
-COMMIT;


### PR DESCRIPTION
## Summary
- dbmate wraps migrations in a transaction by default
- The migration had explicit `BEGIN`/`COMMIT` statements, causing nested transactions
- This produced `pq: unexpected transaction status idle` and crashed the agent container at startup (`db_reset` step)
- Removed the explicit transaction wrappers, letting dbmate handle it

## Note
The infra rules specify `BEGIN; ... COMMIT;` in migrations — this conflicts with dbmate's default behavior. Consider updating the rule to note that dbmate auto-wraps, or use `-- migrate:up transaction:false` for migrations needing manual control.

## Test plan
- [ ] Run `docker compose up` and verify the agent container passes the `db_reset` step
- [ ] Verify the `update_updated_at_column` function exists in the database after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)