### PR TITLE
fix: remove explicit transactions from all migrations

### DIFF
--- a/db/migrations/20260304000002_create_event_store.sql
+++ b/db/migrations/20260304000002_create_event_store.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE events (
   event_id         UUID         NOT NULL DEFAULT gen_random_uuid(),
@@ -39,14 +38,9 @@ CREATE TRIGGER trg_events_no_delete
   FOR EACH ROW
   EXECUTE FUNCTION prevent_events_modification();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_events_no_delete ON events;
 DROP TRIGGER IF EXISTS trg_events_no_update ON events;
 DROP FUNCTION IF EXISTS prevent_events_modification();
 DROP TABLE IF EXISTS events;
-
-COMMIT;

--- a/db/migrations/20260304000003_create_accounts.sql
+++ b/db/migrations/20260304000003_create_accounts.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE accounts (
   id                    UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -24,12 +23,7 @@ CREATE TRIGGER trg_accounts_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_accounts_updated_at ON accounts;
 DROP TABLE IF EXISTS accounts;
-
-COMMIT;

--- a/db/migrations/20260304000004_create_campaigns.sql
+++ b/db/migrations/20260304000004_create_campaigns.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE campaigns (
   id                        UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -43,12 +42,7 @@ CREATE TRIGGER trg_campaigns_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_campaigns_updated_at ON campaigns;
 DROP TABLE IF EXISTS campaigns;
-
-COMMIT;

--- a/db/migrations/20260304000005_create_milestones.sql
+++ b/db/migrations/20260304000005_create_milestones.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE milestones (
   id                     UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -28,12 +27,7 @@ CREATE TRIGGER trg_milestones_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_milestones_updated_at ON milestones;
 DROP TABLE IF EXISTS milestones;
-
-COMMIT;

--- a/db/migrations/20260304000006_create_contributions.sql
+++ b/db/migrations/20260304000006_create_contributions.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE contributions (
   id                 UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -26,12 +25,7 @@ CREATE TRIGGER trg_contributions_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_contributions_updated_at ON contributions;
 DROP TABLE IF EXISTS contributions;
-
-COMMIT;

--- a/db/migrations/20260304000007_create_escrow_ledger.sql
+++ b/db/migrations/20260304000007_create_escrow_ledger.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE escrow_ledger (
   id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -37,14 +36,9 @@ CREATE TRIGGER trg_escrow_ledger_no_delete
   FOR EACH ROW
   EXECUTE FUNCTION prevent_escrow_ledger_modification();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_escrow_ledger_no_delete ON escrow_ledger;
 DROP TRIGGER IF EXISTS trg_escrow_ledger_no_update ON escrow_ledger;
 DROP FUNCTION IF EXISTS prevent_escrow_ledger_modification();
 DROP TABLE IF EXISTS escrow_ledger;
-
-COMMIT;

--- a/db/migrations/20260304000008_create_kyc_verifications.sql
+++ b/db/migrations/20260304000008_create_kyc_verifications.sql
@@ -1,5 +1,4 @@
 -- migrate:up
-BEGIN;
 
 CREATE TABLE kyc_verifications (
   id                  UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -31,12 +30,7 @@ CREATE TRIGGER trg_kyc_verifications_updated_at
   FOR EACH ROW
   EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 
 DROP TRIGGER IF EXISTS trg_kyc_verifications_updated_at ON kyc_verifications;
 DROP TABLE IF EXISTS kyc_verifications;
-
-COMMIT;


### PR DESCRIPTION
## Summary
- PR #19 fixed the first migration but all 7 remaining migrations also had explicit `BEGIN`/`COMMIT` 
- dbmate wraps each migration in its own transaction — the nested transactions cause `pq: unexpected transaction status idle` after the first migration applies
- Removed `BEGIN`/`COMMIT` from all remaining migration files (preserved PL/pgSQL `BEGIN`/`END` blocks in trigger functions)

## Test plan
- [ ] `docker compose up` — agent container should pass `db_reset` step and all 8 migrations apply cleanly
- [ ] Verify all tables and functions exist in the database

🤖 Generated with [Claude Code](https://claude.com/claude-code)