### PR TITLE
fix: reset agent workspace to upstream/main after clone

### DIFF
--- a/autonomous/scripts/agent-entrypoint.sh
+++ b/autonomous/scripts/agent-entrypoint.sh
@@ -52,6 +52,8 @@ if [ -n "${UPSTREAM_REPO}" ]; then
         git remote add upstream "https://github.com/${UPSTREAM_REPO}.git"
     fi
     git fetch upstream main
+    echo "Resetting local main to upstream/main..."
+    git reset --hard upstream/main
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The agent clones from its fork, which drifts behind upstream over time
- The entrypoint already fetched `upstream/main` but never applied it
- Added `git reset --hard upstream/main` after the fetch so the agent always works with the latest upstream code
- Safe because this runs on a fresh clone before any local work begins

## Test plan
- [ ] Merge a change to upstream `main`, restart the agent container without syncing the fork — agent should pick up the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)