### PR TITLE
chore: wire PM pipeline agents to canonical spec documents

### DIFF
--- a/.claude/agents/auditor.md
+++ b/.claude/agents/auditor.md
@@ -15,13 +15,17 @@ You think like a senior staff engineer doing a thorough code review — you chec
 ## Inputs
 
 1. **`CLAUDE.md`** — The constitution. Every rule must be followed.
-2. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — What was supposed to be built.
-3. **The design spec** — `.claude/prds/feat-XXX-design.md` — What the UI was supposed to look like.
-4. **The validation report** — `.claude/prds/feat-XXX-validation.md` — What the spec validator approved.
-5. **The security review** — `.claude/reports/feat-XXX-security.md` — Security findings and their resolution status.
-6. **All code changes for the feature** — Full diff of all new and modified files.
-7. **Test results** — Output of `npm test` and `npx playwright test`.
-8. **Coverage report** — Output of coverage tool.
+2. **`specs/standards/engineering.md`** — Engineering standard (L2-002). Quality gates, security invariants, observability.
+3. **`specs/tech/architecture.md`** — Architecture (L3-001). Hex architecture rules, API versioning, bounded context enforcement.
+4. **`specs/tech/audit.md`** — Audit logging (L3-006). Verify audit event schema compliance.
+5. **`specs/tech/security.md`** — Security (L3-002). Verify security controls match the spec.
+6. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — What was supposed to be built.
+7. **The design spec** — `.claude/prds/feat-XXX-design.md` — What the UI was supposed to look like.
+8. **The validation report** — `.claude/prds/feat-XXX-validation.md` — What the spec validator approved.
+9. **The security review** — `.claude/reports/feat-XXX-security.md` — Security findings and their resolution status.
+10. **All code changes for the feature** — Full diff of all new and modified files.
+11. **Test results** — Output of `npm test` and `npx playwright test`.
+12. **Coverage report** — Output of coverage tool.
 
 ---
 

--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -18,12 +18,18 @@ Before writing any code, read these files in order:
 
 1. **`CLAUDE.md`** — Architecture rules, tech stack, coding standards. Non-negotiable.
 2. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — Data model, domain model, API contracts, business rules, edge cases.
-3. **`specs/tech/tech-stack.md`** — Technology choices. Express 5.x, Pino, PostgreSQL, Zod, etc.
-4. **`specs/domain/payments.md`** — Payment processing rules (escrow, disbursement, refunds).
-5. **`.claude/context/patterns.md`** — Established backend patterns in the codebase.
-6. **`.claude/context/gotchas.md`** — Known pitfalls from previous cycles.
-7. **`.claude/context/domain-knowledge.md`** — Accumulated domain knowledge.
-8. **Current codebase** — Scan `packages/backend/src/` thoroughly. Understand existing domain entities, ports, adapters, services, and API routes. Reuse before you rebuild.
+3. **`specs/standards/engineering.md`** — Engineering standard (L2-002). Security invariants, quality gates, observability.
+4. **`specs/tech/architecture.md`** — Architecture (L3-001). Hex architecture, API versioning, bounded contexts.
+5. **`specs/tech/security.md`** — Security (L3-002). Auth/authz, input validation, encryption.
+6. **`specs/tech/data-management.md`** — Data management (L3-004). Data classification, retention, encryption requirements.
+7. **`specs/tech/audit.md`** — Audit logging (L3-006). Event schema, append-only audit trail.
+8. **Relevant `specs/domain/*.md`** — Read the L4 domain spec(s) for the bounded context(s) this feature touches (not just payments).
+9. **`specs/tech/tech-stack.md`** — Technology choices. Express 5.x, Pino, PostgreSQL, Zod, etc.
+10. **`specs/domain/payments.md`** — Payment processing rules (escrow, disbursement, refunds).
+11. **`.claude/context/patterns.md`** — Established backend patterns in the codebase.
+12. **`.claude/context/gotchas.md`** — Known pitfalls from previous cycles.
+13. **`.claude/context/domain-knowledge.md`** — Accumulated domain knowledge.
+14. **Current codebase** — Scan `packages/backend/src/` thoroughly. Understand existing domain entities, ports, adapters, services, and API routes. Reuse before you rebuild.
 
 ---
 

--- a/.claude/agents/cicd-devops.md
+++ b/.claude/agents/cicd-devops.md
@@ -15,10 +15,12 @@ You think like a platform engineer who values reliability, reproducibility, and 
 ## Inputs
 
 1. **`CLAUDE.md`** — Tech stack, testing requirements, git strategy.
-2. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — Any new CI requirements (new environment variables, new test suites, new deploy targets).
-3. **Infrastructure Engineer's pipeline requirements** — documented in the feature's infra work.
-4. **Current CI/CD config** — `.github/workflows/`, deployment scripts, existing pipeline structure.
-5. **`.ralphrc`** — Safety limits and branch configuration.
+2. **`specs/tech/reliability.md`** — Reliability (L3-003). Health checks, deployment strategy, rollback.
+3. **`specs/standards/engineering.md`** — Engineering standard (L2-002). Quality gates for CI pipeline.
+4. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — Any new CI requirements (new environment variables, new test suites, new deploy targets).
+5. **Infrastructure Engineer's pipeline requirements** — documented in the feature's infra work.
+6. **Current CI/CD config** — `.github/workflows/`, deployment scripts, existing pipeline structure.
+7. **`.ralphrc`** — Safety limits and branch configuration.
 
 ---
 

--- a/.claude/agents/design-speccer.md
+++ b/.claude/agents/design-speccer.md
@@ -18,10 +18,11 @@ Before starting, read these files in order:
 
 1. **`specs/standards/brand.md`** — This is your bible. Every colour, font, spacing value, component pattern, and design principle is here. Memorise it. Your output must be 100% consistent with this document.
 2. **`CLAUDE.md`** — Architecture rules and tech stack. Understand that the frontend is React + TypeScript + Tailwind.
-3. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — the Spec Writer's PRD. Section 7 (Frontend) defines the functional requirements you're designing for.
-4. **The research document** — `.claude/prds/feat-XXX-research.md` — competitor patterns and UX insights.
-5. **`specs/product-vision-and-mission.md`** — User personas. Remember who you're designing for: backers passionate about Mars missions and campaign creators seeking funding.
-6. **Current codebase** — Scan `packages/frontend/src/` to understand existing components, layouts, and patterns already in use.
+3. **`specs/tech/frontend.md`** — Frontend tech standards (L3-005). Component rules, data handling, testing requirements.
+4. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — the Spec Writer's PRD. Section 7 (Frontend) defines the functional requirements you're designing for.
+5. **The research document** — `.claude/prds/feat-XXX-research.md` — competitor patterns and UX insights.
+6. **`specs/product-vision-and-mission.md`** — User personas. Remember who you're designing for: backers passionate about Mars missions and campaign creators seeking funding.
+7. **Current codebase** — Scan `packages/frontend/src/` to understand existing components, layouts, and patterns already in use.
 
 ---
 

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -20,9 +20,10 @@ Before writing any code, read these files in order:
 2. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — API contracts, frontend functional requirements, state management needs, edge cases.
 3. **The design spec** — `.claude/prds/feat-XXX-design.md` — Page layouts, component specs, design tokens, states, responsive behaviour, accessibility requirements.
 4. **`specs/standards/brand.md`** — Global design language. Every visual decision must trace back to this document.
-5. **`.claude/context/patterns.md`** — Established frontend patterns in the codebase.
-6. **`.claude/context/gotchas.md`** — Known pitfalls from previous cycles.
-7. **Current codebase** — Scan `packages/frontend/src/` thoroughly. Understand existing components, layouts, hooks, API client patterns, and routing structure. Reuse before you rebuild.
+5. **`specs/tech/frontend.md`** — Frontend standards (L3-005). Component rules, data handling conventions, testing requirements.
+6. **`.claude/context/patterns.md`** — Established frontend patterns in the codebase.
+7. **`.claude/context/gotchas.md`** — Known pitfalls from previous cycles.
+8. **Current codebase** — Scan `packages/frontend/src/` thoroughly. Understand existing components, layouts, hooks, API client patterns, and routing structure. Reuse before you rebuild.
 
 ---
 

--- a/.claude/agents/infra-engineer.md
+++ b/.claude/agents/infra-engineer.md
@@ -17,11 +17,14 @@ You think like a senior DevOps/platform engineer who cares about reproducibility
 Before starting, read these files in order:
 
 1. **`CLAUDE.md`** — Architecture rules, tech stack, database conventions, infrastructure requirements.
-2. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — Data model changes (migrations), any new AWS resources needed, environment variables, external service requirements.
-3. **`.claude/context/gotchas.md`** — Known infrastructure pitfalls from previous cycles.
-4. **Current infrastructure** — Scan `packages/infrastructure/terraform/` to understand existing Terraform modules, state structure, and resource naming conventions.
-5. **Current migrations** — Scan `db/migrations/` to understand the current schema state and latest migration timestamps.
-6. **`.claude/mock-status.md`** — Which integrations are currently mocked vs real. Determines if infrastructure provisioning is needed now or deferred.
+2. **`specs/tech/architecture.md`** — Architecture (L3-001). Service topology, infrastructure patterns.
+3. **`specs/tech/reliability.md`** — Reliability (L3-003). Recovery, health checks, deployment patterns.
+4. **`specs/tech/data-management.md`** — Data management (L3-004). Backup, retention, encryption at rest.
+5. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — Data model changes (migrations), any new AWS resources needed, environment variables, external service requirements.
+6. **`.claude/context/gotchas.md`** — Known infrastructure pitfalls from previous cycles.
+7. **Current infrastructure** — Scan `packages/infrastructure/terraform/` to understand existing Terraform modules, state structure, and resource naming conventions.
+8. **Current migrations** — Scan `db/migrations/` to understand the current schema state and latest migration timestamps.
+9. **`.claude/mock-status.md`** — Which integrations are currently mocked vs real. Determines if infrastructure provisioning is needed now or deferred.
 
 ---
 

--- a/.claude/agents/integration-engineer.md
+++ b/.claude/agents/integration-engineer.md
@@ -15,12 +15,13 @@ You think like an infrastructure engineer doing a controlled cutover. The mock a
 ## Inputs
 
 1. **`CLAUDE.md`** — Architecture rules, specifically hex architecture and adapter patterns.
-2. **The completed manual task** — `.claude/manual-tasks.md` — the specific task marked as done, with all required config values.
-3. **`.claude/mock-status.md`** — Current mock vs real status for all integrations.
-4. **The mock adapter** — the file currently in use (e.g., `packages/backend/src/[context]/adapters/mock/mock-email-adapter.ts`).
-5. **The real adapter** — either already scaffolded (noted in the manual task) or needs to be created.
-6. **`.env`** — verify the required environment variables are present with real values.
-7. **Current codebase** — understand where the adapter is wired up (`packages/backend/src/app.ts`), how it's injected, and what the port interface requires.
+2. **`specs/tech/security.md`** — Security (L3-002). Credential handling, encryption, auth requirements for external services.
+3. **The completed manual task** — `.claude/manual-tasks.md` — the specific task marked as done, with all required config values.
+4. **`.claude/mock-status.md`** — Current mock vs real status for all integrations.
+5. **The mock adapter** — the file currently in use (e.g., `packages/backend/src/[context]/adapters/mock/mock-email-adapter.ts`).
+6. **The real adapter** — either already scaffolded (noted in the manual task) or needs to be created.
+7. **`.env`** — verify the required environment variables are present with real values.
+8. **Current codebase** — understand where the adapter is wired up (`packages/backend/src/app.ts`), how it's injected, and what the port interface requires.
 
 ---
 

--- a/.claude/agents/product-strategist.md
+++ b/.claude/agents/product-strategist.md
@@ -18,10 +18,12 @@ Before starting, read these files in order:
 
 1. **`CLAUDE.md`** — Architecture rules, tech stack, bounded contexts, coding standards. Understand the constraints.
 2. **`specs/product-vision-and-mission.md`** — The north star. Business context, personas, feature roadmap, success metrics, constraints, and scope boundaries.
-3. **`specs/standards/brand.md`** — Design language and UI patterns. Understand what "on-brand" means.
-4. **`.claude/backlog.md`** — Current backlog state. Check what's already been specced, what's in progress, what's shipped.
-5. **`.claude/context/`** — Any accumulated domain knowledge, patterns, or gotchas from previous cycles.
-6. **Current codebase** — Scan `packages/` to understand what already exists. Don't re-spec things that are already built.
+3. **`specs/README.md`** — Spec index. Understand the full specification hierarchy and cross-references.
+4. **`specs/standards/brand.md`** — Design language and UI patterns. Understand what "on-brand" means.
+5. **`specs/domain/`** — Scan all domain specs (account, campaign, donor, payments, kyc) to understand existing domain boundaries and terminology.
+6. **`.claude/backlog.md`** — Current backlog state. Check what's already been specced, what's in progress, what's shipped.
+7. **`.claude/context/`** — Any accumulated domain knowledge, patterns, or gotchas from previous cycles.
+8. **Current codebase** — Scan `packages/` to understand what already exists. Don't re-spec things that are already built.
 
 ---
 

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -15,10 +15,13 @@ You think like a penetration tester who understands application security, financ
 ## Inputs
 
 1. **`CLAUDE.md`** — Architecture rules, auth requirements, data handling rules.
-2. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — API contracts, auth requirements, error handling.
-3. **All code changes for the feature** — diff of all new and modified files.
-4. **Current codebase** — Scan for existing security patterns (auth middleware, validation, error handling).
-5. **`package.json` / `package-lock.json`** — Dependency list for vulnerability audit.
+2. **`specs/tech/security.md`** — Security spec (L3-002). Threat model, auth/authz mechanisms, encryption requirements, data classification.
+3. **`specs/standards/engineering.md`** — Engineering standard (L2-002). Security invariants and quality gates.
+4. **`specs/tech/data-management.md`** — Data management (L3-004). Data classification levels, encryption requirements, PII handling.
+5. **The feature spec** — `.claude/prds/feat-XXX-spec.md` — API contracts, auth requirements, error handling.
+6. **All code changes for the feature** — diff of all new and modified files.
+7. **Current codebase** — Scan for existing security patterns (auth middleware, validation, error handling).
+8. **`package.json` / `package-lock.json`** — Dependency list for vulnerability audit.
 
 ---
 

--- a/.claude/agents/spec-researcher.md
+++ b/.claude/agents/spec-researcher.md
@@ -18,11 +18,14 @@ Before starting, read these files in order:
 
 1. **`CLAUDE.md`** — Architecture rules, bounded contexts, tech stack, domain rules.
 2. **`specs/product-vision-and-mission.md`** — Business context, user personas, feature scope.
-3. **The feature brief** — The specific feature brief from `.claude/prds/feat-XXX-*.md` assigned to you by the orchestrator. This is your primary input.
-4. **`.claude/context/domain-knowledge.md`** — Accumulated domain knowledge from previous cycles.
-5. **`.claude/context/patterns.md`** — Established code patterns in the codebase.
-6. **`.claude/context/gotchas.md`** — Known pitfalls and issues from previous cycles.
-7. **Current codebase** — Scan `packages/` to understand existing code, data models, API patterns, and integration points.
+3. **`specs/README.md`** — Spec index. Use to identify which L3/L4 specs are relevant to this feature.
+4. **Relevant `specs/domain/*.md`** — Read the L4 domain spec(s) for the bounded context(s) this feature touches (e.g., `specs/domain/campaign.md` for campaign features). These define state machines, business rules, and interface contracts.
+5. **Relevant `specs/tech/*.md`** — Read the L3 tech specs relevant to this feature (e.g., `specs/tech/security.md` for auth-related features, `specs/tech/data-management.md` for data handling features).
+6. **The feature brief** — The specific feature brief from `.claude/prds/feat-XXX-*.md` assigned to you by the orchestrator. This is your primary input.
+7. **`.claude/context/domain-knowledge.md`** — Accumulated domain knowledge from previous cycles.
+8. **`.claude/context/patterns.md`** — Established code patterns in the codebase.
+9. **`.claude/context/gotchas.md`** — Known pitfalls and issues from previous cycles.
+10. **Current codebase** — Scan `packages/` to understand existing code, data models, API patterns, and integration points.
 
 ---
 

--- a/.claude/agents/spec-validator.md
+++ b/.claude/agents/spec-validator.md
@@ -25,9 +25,12 @@ Cross-reference against:
 4. **`CLAUDE.md`** — Architecture rules, coding standards, domain rules
 5. **`specs/product-vision-and-mission.md`** — Feature scope boundaries
 6. **`specs/standards/brand.md`** — Visual design rules
-7. **The feature brief** — `.claude/prds/feat-XXX-*.md` (from Product Strategist) — the original scope definition
-8. **`.claude/backlog.md`** — Dependency tracking and status
-9. **Current codebase** — Scan `packages/` to verify integration assumptions are correct
+7. **`specs/standards/engineering.md`** — Engineering standard (L2-002). Verify spec complies with quality gates and security invariants.
+8. **Relevant `specs/domain/*.md`** — Domain specs for the feature's bounded context(s). Verify state machines, business rules, and interface contracts are respected.
+9. **`specs/tech/architecture.md`** — Architecture spec (L3-001). Verify hex architecture, API versioning, and service topology compliance.
+10. **The feature brief** — `.claude/prds/feat-XXX-*.md` (from Product Strategist) — the original scope definition
+11. **`.claude/backlog.md`** — Dependency tracking and status
+12. **Current codebase** — Scan `packages/` to verify integration assumptions are correct
 
 ---
 

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -18,11 +18,13 @@ Before starting, read these files in order:
 
 1. **`CLAUDE.md`** — Architecture rules, bounded contexts, tech stack, coding standards, domain rules. Your spec must comply with every rule in this file.
 2. **`specs/product-vision-and-mission.md`** — Business context and feature scope. Your spec must stay within the vision's boundaries.
-3. **The feature brief** — `.claude/prds/feat-XXX-*.md` — the Product Strategist's feature brief. This defines WHAT to build.
-4. **The research document** — `.claude/prds/feat-XXX-research.md` — the Spec Researcher's output. This gives you domain knowledge, codebase context, API details, and edge cases.
-5. **`specs/standards/brand.md`** — Design language and UI patterns. Reference this for any frontend-facing aspects of the spec.
-6. **`.claude/context/patterns.md`** — Established code patterns. Your spec should follow existing patterns, not invent new ones.
-7. **Current codebase** — Scan `packages/` to understand existing data models, entities, and API patterns that your spec must integrate with.
+3. **Relevant `specs/domain/*.md`** — Read the L4 domain spec(s) for the bounded context(s) this feature touches. These define state machines, entity lifecycles, business rules, and invariants that the spec must respect.
+4. **`specs/standards/engineering.md`** — Engineering standard (L2-002). Quality gates, security invariants, observability requirements.
+5. **The feature brief** — `.claude/prds/feat-XXX-*.md` — the Product Strategist's feature brief. This defines WHAT to build.
+6. **The research document** — `.claude/prds/feat-XXX-research.md` — the Spec Researcher's output. This gives you domain knowledge, codebase context, API details, and edge cases.
+7. **`specs/standards/brand.md`** — Design language and UI patterns. Reference this for any frontend-facing aspects of the spec.
+8. **`.claude/context/patterns.md`** — Established code patterns. Your spec should follow existing patterns, not invent new ones.
+9. **Current codebase** — Scan `packages/` to understand existing data models, entities, and API patterns that your spec must integrate with.
 
 ---
 

--- a/.claude/commands/pm/pipeline-start.md
+++ b/.claude/commands/pm/pipeline-start.md
@@ -20,6 +20,8 @@ You are the **Pipeline Orchestrator**. Your job is to run the continuous product
    - Read `CLAUDE.md` — understand all rules and constraints
    - Read `specs/product-vision-and-mission.md` — understand what we're building
    - Read `specs/standards/brand.md` — understand how it should look
+   - Read `specs/README.md` — understand the full specification hierarchy
+   - Read `specs/standards/engineering.md` — understand quality gates
    - Read `.claude/backlog.md` — understand current state
 
 2. **Verify git state:**

--- a/.claude/commands/pm/spec-plan.md
+++ b/.claude/commands/pm/spec-plan.md
@@ -19,6 +19,8 @@ Run this when the backlog is empty or needs regenerating from the vision.
    - Read `CLAUDE.md`
    - Read `specs/product-vision-and-mission.md`
    - Read `specs/standards/brand.md`
+   - Read `specs/README.md` — understand the full specification hierarchy
+   - Read `specs/standards/engineering.md` — understand quality gates
    - Read `.claude/backlog.md` — check current state
    - Scan `packages/` — understand what already exists
 


### PR DESCRIPTION
## Summary

- Adds missing spec file references to 12 agent definitions and 2 command files so all 16 specs are consulted by at least one agent
- Previously only 3 of 16 spec documents were referenced — rules from the other 13 were hardcoded inline, creating drift risk
- All domain specs are now reachable via wildcard `specs/domain/*.md` references; L2/L3 specs are referenced explicitly by the agents that need them

## Test plan

- [x] `grep -r "specs/" .claude/agents/ .claude/commands/pm/` confirms all 16 spec files are referenced
- [x] Cross-checked references against `ls specs/**/*.md` — no references to non-existent files
- [x] Verified input numbering is sequential and consistent in all 14 modified files
- [ ] Run `/pm:spec-plan --continue` on a test feature to verify agents read the new inputs without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)