### PR TITLE
fix: remove skip-worktree on untracked .pre-commit-config.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,9 @@ test-results/
 !*.tfvars.example
 .terraform.lock.hcl
 
+# Pre-commit config — copied into workspace at runtime by autonomous agent (autonomous/scripts/agent-entrypoint.sh)
+.pre-commit-config.yaml
+
 # IDE
 .vscode/
 !.vscode/extensions.json

--- a/autonomous/scripts/agent-entrypoint.sh
+++ b/autonomous/scripts/agent-entrypoint.sh
@@ -82,7 +82,6 @@ fi
 STEP="prek"
 echo "Installing prek pre-commit hooks..."
 cp /opt/agent/scripts/.pre-commit-config.yaml /workspace/.pre-commit-config.yaml
-git update-index --skip-worktree .pre-commit-config.yaml
 prek install
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Removed `git update-index --skip-worktree .pre-commit-config.yaml` from the agent entrypoint — it fails because the file is untracked (copied at runtime, never committed)
- Added `.pre-commit-config.yaml` to `.gitignore` with a comment pointing to the entrypoint script that copies it

## Test plan
- [ ] Run `./autonomous/start.sh` and verify the agent container passes the `prek` step without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)