### PR TITLE
fix: fix prek YAML parsing and add seed migration

### DIFF
--- a/autonomous/scripts/.pre-commit-config.yaml
+++ b/autonomous/scripts/.pre-commit-config.yaml
@@ -3,32 +3,38 @@ repos:
     hooks:
       - id: check-merge-conflict
         name: check-merge-conflict
-        entry: sh -c 'if grep -rn "<<<<<<< \|=======$\|>>>>>>> " -- "$@" 2>/dev/null; then echo "Merge conflict markers found"; exit 1; fi; exit 0'
+        entry: >-
+          sh -c 'if grep -rn "<<<<<<< \|=======$\|>>>>>>> " -- "$@" 2>/dev/null; then echo "Merge conflict markers found"; exit 1; fi; exit 0'
         language: system
         types: [text]
       - id: detect-private-key
         name: detect-private-key
-        entry: sh -c 'if grep -rn "BEGIN.*PRIVATE KEY" -- "$@" 2>/dev/null; then echo "Private key detected"; exit 1; fi; exit 0'
+        entry: >-
+          sh -c 'if grep -rn "BEGIN.*PRIVATE KEY" -- "$@" 2>/dev/null; then echo "Private key detected"; exit 1; fi; exit 0'
         language: system
         types: [text]
       - id: end-of-file-fixer
         name: end-of-file-fixer
-        entry: sh -c 'for f in "$@"; do [ -s "$f" ] && [ "$(tail -c1 "$f" | xxd -p)" != "0a" ] && echo "" >> "$f" && echo "Fixed EOF: $f"; done; exit 0'
+        entry: >-
+          sh -c 'for f in "$@"; do [ -s "$f" ] && [ "$(tail -c1 "$f" | xxd -p)" != "0a" ] && echo "" >> "$f" && echo "Fixed EOF: $f"; done; exit 0'
         language: system
         types: [text]
       - id: trailing-whitespace
         name: trailing-whitespace
-        entry: sh -c 'sed -i "s/[[:space:]]*$//" "$@"'
+        entry: >-
+          sh -c 'sed -i "s/[[:space:]]*$//" "$@"'
         language: system
         types: [text]
       - id: check-json
         name: check-json
-        entry: sh -c 'for f in "$@"; do jq . < "$f" > /dev/null || exit 1; done'
+        entry: >-
+          sh -c 'for f in "$@"; do jq . < "$f" > /dev/null || exit 1; done'
         language: system
         types: [json]
       - id: no-commit-to-branch
         name: no-commit-to-branch
-        entry: sh -c '[ "$(git branch --show-current)" != "main" ]'
+        entry: >-
+          sh -c '[ "$(git branch --show-current)" != "main" ]'
         language: system
         always_run: true
         pass_filenames: false

--- a/autonomous/scripts/reset-db.sh
+++ b/autonomous/scripts/reset-db.sh
@@ -33,20 +33,21 @@ echo "Creating database ${DB_NAME}..."
 psql -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d postgres \
     -c "CREATE DATABASE ${DB_NAME};"
 
-# Apply migrations with retry logic
+# Apply migrations (only if migration files exist)
+MIGRATIONS_DIR="${DBMATE_MIGRATIONS_DIR:-db/migrations}"
+if [ ! -d "${MIGRATIONS_DIR}" ] || [ -z "$(ls -A "${MIGRATIONS_DIR}" 2>/dev/null)" ]; then
+    echo "No migration files found in ${MIGRATIONS_DIR}, skipping dbmate."
+    echo "Database reset complete (empty database)."
+    exit 0
+fi
+
 MAX_ATTEMPTS=3
 BACKOFF_SECONDS=(0 5 15)
 
 for attempt in $(seq 1 "${MAX_ATTEMPTS}"); do
     echo "Running dbmate migrations (attempt ${attempt}/${MAX_ATTEMPTS})..."
 
-    DBMATE_ARGS="--url ${DB_URL} up"
-    if [ "${attempt}" -ge 2 ]; then
-        echo "Using --no-tx-wrap fallback (handles double-transaction issues)..."
-        DBMATE_ARGS="--url ${DB_URL} --no-tx-wrap up"
-    fi
-
-    if dbmate ${DBMATE_ARGS} 2>&1; then
+    if dbmate --url "${DB_URL}" up 2>&1; then
         echo "Database reset complete."
         exit 0
     fi

--- a/db/migrations/20260305120000_add_updated_at_trigger.sql
+++ b/db/migrations/20260305120000_add_updated_at_trigger.sql
@@ -1,0 +1,19 @@
+-- migrate:up
+BEGIN;
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMIT;
+
+-- migrate:down
+BEGIN;
+
+DROP FUNCTION IF EXISTS update_updated_at_column();
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Use YAML folded scalars (`>-`) for shell `entry` values containing colons, fixing prek parse errors
- Add `updated_at` trigger as seed migration so dbmate has something to run
- Remove invalid `--no-tx-wrap` fallback flag from `reset-db.sh`

## Test plan
- [ ] Run `./autonomous/start.sh` and verify prek installs without YAML warnings
- [ ] Verify dbmate applies the seed migration successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)