### PR TITLE
fix: remove double transaction in migration and guard dev script

### DIFF
--- a/autonomous/scripts/agent-entrypoint.sh
+++ b/autonomous/scripts/agent-entrypoint.sh
@@ -117,7 +117,7 @@ fi
 # ---------------------------------------------------------------------------
 STEP="dev_stack"
 DEV_PID=""
-if [ -f package.json ]; then
+if [ -f package.json ] && node -e "process.exit(require('./package.json').scripts?.dev ? 0 : 1)" 2>/dev/null; then
     echo "Starting dev stack in background..."
     npm run dev &
     DEV_PID=$!
@@ -132,7 +132,7 @@ if [ -f package.json ]; then
         echo "Warning: dev stack not responding after 60s, continuing anyway."
     fi
 else
-    echo "No package.json found, skipping dev stack."
+    echo "No dev script found, skipping dev stack."
 fi
 
 # ---------------------------------------------------------------------------

--- a/db/migrations/20260305120000_add_updated_at_trigger.sql
+++ b/db/migrations/20260305120000_add_updated_at_trigger.sql
@@ -1,6 +1,4 @@
 -- migrate:up
-BEGIN;
-
 CREATE OR REPLACE FUNCTION update_updated_at_column()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -9,11 +7,5 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
-
 DROP FUNCTION IF EXISTS update_updated_at_column();
-
-COMMIT;


### PR DESCRIPTION
## Summary
- Remove explicit `BEGIN`/`COMMIT` from seed migration — dbmate wraps migrations in a transaction by default, causing `pq: unexpected transaction status idle`
- Check for a `dev` script in `package.json` before running `npm run dev` so the agent doesn't fail when no dev stack exists yet

## Test plan
- [ ] Run `./autonomous/start.sh` and verify migrations apply cleanly on first attempt
- [ ] Verify the dev stack step is skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)