### PR TITLE
feat: pass Clerk keys to autonomous agent

### DIFF
--- a/autonomous/.env.agent.example
+++ b/autonomous/.env.agent.example
@@ -34,3 +34,13 @@ DATABASE_URL=postgres://mmf:mmf@postgres:5432/mmf?sslmode=disable
 
 WEB_URL=http://localhost:5173
 MAX_RUNTIME=43200
+
+# --- Authentication (Clerk) — needed by the dev stack ----------------------
+
+CLERK_PUBLISHABLE_KEY=pk_test_placeholder
+CLERK_SECRET_KEY=sk_test_placeholder
+VITE_CLERK_PUBLISHABLE_KEY=pk_test_placeholder
+CLERK_WEBHOOK_SIGNING_SECRET=whsec_placeholder
+
+# Clerk instance domain for firewall allowlist (derived from publishable key)
+CLERK_INSTANCE_DOMAIN=promoted-tiger-9.clerk.accounts.dev

--- a/autonomous/Dockerfile.agent
+++ b/autonomous/Dockerfile.agent
@@ -77,7 +77,7 @@ RUN npx playwright install --with-deps chromium
 RUN useradd -m -s /bin/bash agent \
     && mkdir -p /workspace /artifacts /home/agent/.cache /home/agent/.npm \
     && chown -R agent:agent /workspace /artifacts /home/agent \
-    && echo "agent ALL=(root) NOPASSWD: /opt/agent/scripts/init-firewall.sh" > /etc/sudoers.d/agent-firewall \
+    && echo "agent ALL=(root) NOPASSWD:SETENV: /opt/agent/scripts/init-firewall.sh" > /etc/sudoers.d/agent-firewall \
     && chmod 0440 /etc/sudoers.d/agent-firewall
 
 # ---------------------------------------------------------------------------

--- a/autonomous/scripts/agent-entrypoint.sh
+++ b/autonomous/scripts/agent-entrypoint.sh
@@ -62,6 +62,54 @@ if [ -n "${UPSTREAM_REPO}" ]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Step 1c: Generate .env from template with container env vars
+# ---------------------------------------------------------------------------
+STEP="dotenv"
+if [ -f .env.example ]; then
+    echo "Generating .env from .env.example..."
+    cp .env.example .env
+
+    # Override placeholder values with env vars set in the container
+    ENV_VARS=(
+        DATABASE_URL
+        POSTGRES_USER
+        POSTGRES_PASSWORD
+        POSTGRES_DB
+        PORT
+        NODE_ENV
+        LOG_LEVEL
+        VITE_API_URL
+        CLERK_PUBLISHABLE_KEY
+        CLERK_SECRET_KEY
+        VITE_CLERK_PUBLISHABLE_KEY
+        CLERK_WEBHOOK_SIGNING_SECRET
+        MOCK_PAYMENTS
+        MOCK_KYC
+        MOCK_EMAIL
+        MOCK_AUTH
+        POSTHOG_API_KEY
+        POSTHOG_HOST
+    )
+
+    for var in "${ENV_VARS[@]}"; do
+        val="${!var:-}"
+        if [ -n "${val}" ]; then
+            # Replace existing line or append if commented out / missing
+            if grep -qE "^${var}=" .env; then
+                sed -i "s|^${var}=.*|${var}=${val}|" .env
+            elif grep -qE "^#.*${var}=" .env; then
+                sed -i "s|^#.*${var}=.*|${var}=${val}|" .env
+            else
+                echo "${var}=${val}" >> .env
+            fi
+        fi
+    done
+    echo ".env generated."
+else
+    echo "No .env.example found, skipping .env generation."
+fi
+
+# ---------------------------------------------------------------------------
 # Step 2: Install dependencies
 # ---------------------------------------------------------------------------
 STEP="npm_install"
@@ -89,7 +137,7 @@ prek install
 # ---------------------------------------------------------------------------
 STEP="firewall"
 echo "Initialising firewall..."
-sudo /opt/agent/scripts/init-firewall.sh
+sudo CLERK_INSTANCE_DOMAIN="${CLERK_INSTANCE_DOMAIN:-}" /opt/agent/scripts/init-firewall.sh
 
 # ---------------------------------------------------------------------------
 # Step 4: Reset database

--- a/autonomous/scripts/init-firewall.sh
+++ b/autonomous/scripts/init-firewall.sh
@@ -18,6 +18,9 @@ ipset create allowed_hosts hash:ip hashsize 4096 timeout 0 2>/dev/null || ipset 
 # ---------------------------------------------------------------------------
 # Allowed domains — resolve to IPs
 # ---------------------------------------------------------------------------
+# Clerk instance domain — derived from publishable key; override via env var
+CLERK_INSTANCE_DOMAIN="${CLERK_INSTANCE_DOMAIN:-promoted-tiger-9.clerk.accounts.dev}"
+
 ALLOWED_DOMAINS=(
     github.com
     api.github.com
@@ -27,6 +30,10 @@ ALLOWED_DOMAINS=(
     statsig.anthropic.com
     cdn.clerk.io
     us.posthog.com
+    clerk.accounts.dev
+    "${CLERK_INSTANCE_DOMAIN}"
+    api.clerk.dev
+    clerk.dev
 )
 
 for domain in "${ALLOWED_DOMAINS[@]}"; do


### PR DESCRIPTION
## Summary

- Add Clerk key placeholders (`CLERK_PUBLISHABLE_KEY`, `CLERK_SECRET_KEY`, `VITE_CLERK_PUBLISHABLE_KEY`, `CLERK_WEBHOOK_SIGNING_SECRET`) and `CLERK_INSTANCE_DOMAIN` to `.env.agent.example`
- Generate `.env` from `.env.example` in the entrypoint (Step 1c) after clone, overriding placeholders with container env vars so the dev stack picks up real Clerk keys, database URL, etc.
- Add Clerk auth domains (`clerk.accounts.dev`, instance domain, `api.clerk.dev`, `clerk.dev`) to the firewall allowlist with dynamic `CLERK_INSTANCE_DOMAIN` support
- Update sudoers to `SETENV` so the instance domain env var passes through `sudo` to the firewall script

## Test plan

- [ ] Verify `.env.agent.example` has the new Clerk vars documented
- [ ] `docker compose build` in `autonomous/` succeeds
- [ ] Run agent container and confirm `.env` is generated with correct values from container env
- [ ] Confirm firewall resolves and allows Clerk domains
- [ ] Dev stack starts and Clerk auth works (JWT verification + login UI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)