### PR TITLE
fix: propagate runtime environment context to agent subagents

### DIFF
--- a/.claude/agents/product-strategist.md
+++ b/.claude/agents/product-strategist.md
@@ -16,14 +16,15 @@ You think like a product manager who deeply understands both the business model 
 
 Before starting, read these files in order:
 
-1. **`CLAUDE.md`** — Architecture rules, tech stack, bounded contexts, coding standards. Understand the constraints.
-2. **`specs/product-vision-and-mission.md`** — The north star. Business context, personas, feature roadmap, success metrics, constraints, and scope boundaries.
-3. **`specs/README.md`** — Spec index. Understand the full specification hierarchy and cross-references.
-4. **`specs/standards/brand.md`** — Design language and UI patterns. Understand what "on-brand" means.
-5. **`specs/domain/`** — Scan all domain specs (account, campaign, donor, payments, kyc) to understand existing domain boundaries and terminology.
-6. **`.claude/backlog.md`** — Current backlog state. Check what's already been specced, what's in progress, what's shipped.
-7. **`.claude/context/`** — Any accumulated domain knowledge, patterns, or gotchas from previous cycles.
-8. **Current codebase** — Scan `packages/` to understand what already exists. Don't re-spec things that are already built.
+1. **`.claude/context/runtime-environment.md`** — Runtime environment constraints. Read this first to understand what infrastructure already exists. **Do not create features for infrastructure that is already provided.**
+2. **`CLAUDE.md`** — Architecture rules, tech stack, bounded contexts, coding standards. Understand the constraints.
+3. **`specs/product-vision-and-mission.md`** — The north star. Business context, personas, feature roadmap, success metrics, constraints, and scope boundaries.
+4. **`specs/README.md`** — Spec index. Understand the full specification hierarchy and cross-references.
+5. **`specs/standards/brand.md`** — Design language and UI patterns. Understand what "on-brand" means.
+6. **`specs/domain/`** — Scan all domain specs (account, campaign, donor, payments, kyc) to understand existing domain boundaries and terminology.
+7. **`.claude/backlog.md`** — Current backlog state. Check what's already been specced, what's in progress, what's shipped.
+8. **`.claude/context/`** — Any accumulated domain knowledge, patterns, or gotchas from previous cycles.
+9. **Current codebase** — Scan `packages/` to understand what already exists. Don't re-spec things that are already built.
 
 ---
 
@@ -142,6 +143,7 @@ Write the prioritised backlog to `.claude/backlog.md` in this format:
 - **Don't spec Phase 2 features** — features beyond the defined MVP scope are explicitly out of scope.
 - **Don't create features smaller than a meaningful unit of work** — "Add a button" is not a feature. "Campaign creation with milestone definition and validation" is.
 - **Don't create features larger than one agent cycle** — if a feature brief is more than one page, it's too big. Split it.
+- **Don't create infrastructure setup features** — no "monorepo setup", "Docker Compose", "local dev environment", or "project scaffolding" features. The dev environment is pre-built. Start with application features that deliver user value.
 
 ---
 

--- a/autonomous/scripts/agent-entrypoint.sh
+++ b/autonomous/scripts/agent-entrypoint.sh
@@ -183,6 +183,36 @@ git push -u origin "${BRANCH_NAME}"
 echo "Working on branch: ${BRANCH_NAME}"
 
 # ---------------------------------------------------------------------------
+# Step 5b: Write runtime environment context for subagents
+# ---------------------------------------------------------------------------
+STEP="runtime_context"
+mkdir -p .claude/context
+cat > .claude/context/runtime-environment.md <<'RUNTIME_EOF'
+# Runtime Environment
+
+You are running inside an isolated Docker container (Debian/Node 22). The local development infrastructure is already set up — do not recreate it.
+
+## What is already running
+
+- **PostgreSQL** at `postgres:5432` (user: `mmf`, password: `mmf`, db: `mmf`). All migrations applied. `DATABASE_URL` is set.
+- **Dev stack** — backend at `localhost:3000`, frontend at `localhost:5173`. Restart with `make dev-stack`.
+- **Pre-installed tools:** `node`, `npm`, `dbmate`, `psql`, `gh`, `playwright` (Chromium), `biome`, `prek`, `gitleaks`, `curl`, `jq`
+
+## What is NOT available
+
+- **No Docker daemon** — you are INSIDE a container. Never create `docker-compose.yml`, Dockerfiles, or Docker-based dev setup.
+- **No outbound HTTPS** except: GitHub, npm, Anthropic, Clerk, PostHog.
+- **No sudo / no package installs.**
+
+## Implications for feature planning
+
+- Do NOT create features for "project setup", "monorepo scaffolding", "Docker Compose", or "local dev environment". These are solved.
+- Feature briefs must describe **application features** (user-facing value), not infrastructure.
+- Acceptance criteria must never reference `docker-compose`, `Dockerfile`, or container provisioning.
+RUNTIME_EOF
+echo "Runtime environment context written."
+
+# ---------------------------------------------------------------------------
 # Step 6: Run Claude Code
 # ---------------------------------------------------------------------------
 STEP="claude"


### PR DESCRIPTION
## Summary
- The prompt template only reaches the top-level Claude instance — subagents (product strategist, engineers, etc.) never see it, so they planned Docker/infra features impossible inside the container
- Entrypoint now writes `.claude/context/runtime-environment.md` into the workspace at startup, making environment context discoverable by all subagents
- Product strategist reads it as input #1 and has an explicit DON'T rule against infrastructure setup features

## Test plan
- [ ] Run the autonomous agent and verify the product strategist no longer creates "monorepo setup" or "Docker Compose" features
- [ ] Verify `.claude/context/runtime-environment.md` exists in the workspace after entrypoint runs
- [ ] Confirm feat-001 is an application feature (e.g. auth, landing page) not infrastructure scaffolding

🤖 Generated with [Claude Code](https://claude.com/claude-code)