### PR TITLE
fix: move dev environment context to CLAUDE.md so all agents see it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,25 @@ MarsMissionFund is a sample application for coding workshops — a fake product 
 The [specs/README.md](./specs/README.md) document acts as index for the Product Mission and the standards for the project.
 Before implementing any feature, consult the specifications in [specs/README.md](./specs/README.md).
 
+## Development Environment
+
+The local dev environment requires PostgreSQL running and accessible. All other external services (Stripe, Clerk, Veriff, AWS SES) are mocked — see `.env.example` for configuration.
+
+### Prerequisites
+
+- Node.js 22.x LTS and npm
+- PostgreSQL 16 (via Docker Compose: `docker compose up -d`)
+- dbmate for migrations (`npm run migrate` or `dbmate up`)
+
+### Already provided — do not recreate
+
+- **PostgreSQL** is provisioned via Docker Compose (see `docker-compose.yml` at project root). Do not create additional database infrastructure.
+- **Dev stack** starts with `npm run dev` (backend at `localhost:3000`, frontend at `localhost:5173`). Restart with `make dev-stack` if needed.
+- **Database migrations** live in `db/migrations/` and are applied with dbmate. Do not create alternative migration tooling.
+- **Pre-installed tooling:** dbmate, Biome (lint/format), Playwright (E2E), Vitest (unit/integration).
+
+Do not create features or specs for "project setup", "monorepo scaffolding", "Docker Compose configuration", or "local dev environment". This infrastructure exists. Features should deliver application-level user value.
+
 ## Development Workflow
 
 TODO: Document the development workflow, including git standards, testing, reviews etc.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,18 +13,18 @@ Before implementing any feature, consult the specifications in [specs/README.md]
 
 ## Development Environment
 
-The local dev environment requires PostgreSQL running and accessible. All other external services (Stripe, Clerk, Veriff, AWS SES) are mocked — see `.env.example` for configuration.
+PostgreSQL must be running and accessible via `DATABASE_URL` (set in `.env`). All other external services (Stripe, Clerk, Veriff, AWS SES) are mocked — see `.env.example` for configuration.
 
-### Prerequisites
+### Prerequisites (human developers only — already satisfied in agent container)
 
 - Node.js 22.x LTS and npm
-- PostgreSQL 16 (via Docker Compose: `docker compose up -d`)
+- PostgreSQL 16
 - dbmate for migrations (`npm run migrate` or `dbmate up`)
 
 ### Already provided — do not recreate
 
-- **PostgreSQL** is provisioned via Docker Compose (see `docker-compose.yml` at project root). Do not create additional database infrastructure.
-- **Dev stack** starts with `npm run dev` (backend at `localhost:3000`, frontend at `localhost:5173`). Restart with `make dev-stack` if needed.
+- **PostgreSQL** — connection details come from `DATABASE_URL` in `.env`. Never hardcode connection strings.
+- **Dev stack** starts with `npm run dev` (backend at `localhost:3001`, frontend at `localhost:5173`). Restart with `make dev-stack` if needed.
 - **Database migrations** live in `db/migrations/` and are applied with dbmate. Do not create alternative migration tooling.
 - **Pre-installed tooling:** dbmate, Biome (lint/format), Playwright (E2E), Vitest (unit/integration).
 

--- a/autonomous/scripts/prompt-template.md
+++ b/autonomous/scripts/prompt-template.md
@@ -1,20 +1,13 @@
-## Runtime Environment — READ THIS FIRST
+## Autonomous Agent Context
 
-You are running inside an isolated Docker container (Debian/Node 22). Before you started, the entrypoint already: cloned the repo to `/workspace`, ran `npm ci`, generated `.env` from `.env.example`, configured pre-commit hooks (prek), reset the database with all migrations applied, started the dev stack, and created a working branch.
+You are running inside an isolated Docker container. The entrypoint has already cloned the repo, installed dependencies, generated `.env`, applied all database migrations, started the dev stack, and created a working branch. Read `CLAUDE.md` for the full development environment description.
 
-### What is already running
+### Container-specific constraints
 
-- **PostgreSQL** at `postgres:5432` (user: `mmf`, password: `mmf`, db: `mmf`). All migrations applied. `DATABASE_URL` is set. Do NOT provision or start a database — just use it.
-- **Dev stack** — backend at `localhost:3000`, frontend at `localhost:5173`. Restart with `make dev-stack` after migrations or code changes.
-- **Pre-installed tools:** `node`, `npm`, `dbmate`, `psql`, `gh`, `playwright` (Chromium), `biome`, `prek`, `gitleaks`, `curl`, `jq`
-
-### What is NOT available
-
-- **No Docker daemon** — you are INSIDE a container. Never create `docker-compose.yml`, Dockerfiles, or Docker-based dev setup. The dev environment is this container.
+- **No Docker daemon** — you are INSIDE a container. Never create `docker-compose.yml`, Dockerfiles, or Docker-based dev setup.
 - **No outbound HTTPS** except allowlisted domains (GitHub, npm, Anthropic, Clerk, PostHog). Use WebSearch instead of WebFetch for docs.
 - **No sudo / no package installs** — work with what's pre-installed.
-
-Feature briefs and specs should describe application features, not infrastructure setup. The local infrastructure is already solved.
+- **Additional tools available:** `psql`, `gh`, `prek`, `gitleaks`, `curl`, `jq`
 
 ### Escalation — when to alert a human
 


### PR DESCRIPTION
## Summary
- Moves dev environment documentation into `CLAUDE.md` — the one file every agent and human developer reads first
- Eliminates the need to patch individual agent files (previous approach in #35 only fixed the product strategist, leaving 12+ other agents unaware)
- Prompt template slimmed to container-specific constraints only (no Docker daemon, firewall, escalation path)

Supersedes #35 — that PR can be closed.

## Test plan
- [ ] Run the autonomous agent and verify feat-001 is an application feature, not infrastructure scaffolding
- [ ] Verify a human developer reading `CLAUDE.md` understands the prerequisites (Postgres, dbmate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)