### PR TITLE
fix: install Playwright correctly in agent Docker container

### DIFF
--- a/autonomous/Dockerfile.agent
+++ b/autonomous/Dockerfile.agent
@@ -64,12 +64,15 @@ RUN ARCH=$(uname -m) && [ "$ARCH" = "aarch64" ] && ARCH="arm64" || ARCH="x64" \
 RUN npm install -g \
         "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
         "@biomejs/biome@${BIOME_VERSION}" \
-        "@j178/prek@${PREK_VERSION}"
+        "@j178/prek@${PREK_VERSION}" \
+        "@playwright/cli@0.1.1"
 
 # ---------------------------------------------------------------------------
 # Playwright (Chromium only — saves ~1 GB vs all browsers)
 # ---------------------------------------------------------------------------
-RUN npx playwright install --with-deps chromium
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+RUN npx --package @playwright/cli playwright install --with-deps chromium \
+    && chmod -R o+rx "${PLAYWRIGHT_BROWSERS_PATH}"
 
 # ---------------------------------------------------------------------------
 # Non-root agent user


### PR DESCRIPTION
## Summary

- Adds `@playwright/cli@0.1.1` to global npm installs so `playwright-cli` is on PATH for all users
- Sets `PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers` so build-time install and runtime lookup share the same location
- Installs Chromium using the matching playwright version (`1.59.0-alpha`) and grants the non-root `agent` user read/execute access

Closes #37

## Test plan

- [x] `docker compose -f autonomous/docker-compose.yml build agent` — image builds successfully
- [x] `which playwright-cli` → `/usr/local/bin/playwright-cli`
- [x] `ls /opt/playwright-browsers/` → `chromium-1212`, `chromium_headless_shell-1212`, `ffmpeg-1011`
- [x] `whoami && playwright-cli open --help` as `agent` user — works without permission errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)