### PR TITLE
fix: remove explicit BEGIN/COMMIT from migration rules

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -409,8 +409,6 @@ Migrations are managed by **dbmate**. Files live in `db/migrations/` at the proj
 **Template:**
 ```sql
 -- migrate:up
-BEGIN;
-
 CREATE TABLE IF NOT EXISTS campaigns (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     creator_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
@@ -433,17 +431,13 @@ CREATE TRIGGER update_campaigns_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 DROP TABLE IF EXISTS campaigns;
-COMMIT;
 ```
 
 **Migration rules:**
 - Append-only — NEVER modify existing migration files
-- Wrapped in `BEGIN; ... COMMIT;` for transactional safety
+- Do NOT wrap in `BEGIN; ... COMMIT;` — dbmate handles transactions automatically
 - Monetary columns: `BIGINT` for cents — never FLOAT/DOUBLE/REAL
 - All tables: `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`
 - Date columns: `TIMESTAMPTZ` — never TIMESTAMP without timezone

--- a/.claude/agents/infra-engineer.md
+++ b/.claude/agents/infra-engineer.md
@@ -46,8 +46,6 @@ Implement every data model change from the feature spec. The Backend Engineer ma
 -- Description: [What this migration does]
 -- Author: infra-engineer-agent
 
-BEGIN;
-
 -- ============================================================
 -- New tables
 -- ============================================================
@@ -99,16 +97,12 @@ CREATE TRIGGER update_[table]_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_updated_at_column();
 
-COMMIT;
-
 -- migrate:down
-BEGIN;
 DROP TABLE IF EXISTS [table_name];
-COMMIT;
 ```
 
 **Migration rules:**
-- Always wrap in `BEGIN; ... COMMIT;` for transactional safety
+- Do NOT wrap in `BEGIN; ... COMMIT;` — dbmate handles transactions automatically
 - `CREATE TABLE IF NOT EXISTS` — idempotent where possible
 - All monetary columns: `BIGINT` (integer cents) — never FLOAT/DOUBLE/REAL/NUMERIC for money
 - Percentage columns: `NUMERIC(5,2)` where needed
@@ -127,7 +121,7 @@ COMMIT;
 ```markdown
 - [ ] Timestamp naming format (YYYYMMDDHHMMSS) — no duplicate timestamps
 - [ ] Has both `-- migrate:up` and `-- migrate:down` sections
-- [ ] Wrapped in BEGIN/COMMIT inside the up section
+- [ ] NOT wrapped in BEGIN/COMMIT (dbmate handles transactions)
 - [ ] All NUMERIC columns have correct precision
 - [ ] All tenant tables have user_id with FK
 - [ ] All tables have created_at and updated_at

--- a/.claude/rules/infra.md
+++ b/.claude/rules/infra.md
@@ -26,7 +26,7 @@
 - Run locally: `dbmate up` (via docker-compose service or direct binary)
 - Run in CI/CD: `dbmate up` as a step before application deployment
 - Append-only — never modify existing migrations
-- `-- migrate:up` section wrapped in `BEGIN; ... COMMIT;`
+- Do NOT wrap migrations in `BEGIN; ... COMMIT;` — dbmate wraps each migration in a transaction automatically
 - `CREATE TABLE IF NOT EXISTS` where possible
 - Monetary columns: `BIGINT` (integer cents) — never FLOAT/DOUBLE/REAL/NUMERIC for money
 - All tables: `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`


### PR DESCRIPTION
## Summary

- Removes the rule requiring `BEGIN; ... COMMIT;` wrapping in migration files — dbmate already wraps each migration in a transaction, so explicit wrappers cause nested transactions and `pq: unexpected transaction status idle` errors
- Updates migration templates in `.claude/agents/backend-engineer.md` and `.claude/agents/infra-engineer.md` to remove `BEGIN;`/`COMMIT;` blocks
- Updates the migration validation checklist to check that migrations are NOT wrapped

Closes #42

## Test plan

- [x] Grep confirms no remaining `BEGIN/COMMIT` wrapping instructions in rules or templates
- [x] Existing migration file (`db/migrations/20260305120000_add_updated_at_trigger.sql`) unchanged — its `BEGIN` is PL/pgSQL function body syntax, not a transaction wrapper
- [ ] Run `dbmate up` against a test database to confirm migrations apply cleanly without nested transaction errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)