### PR TITLE
docs: add glossary and spec conflict resolution guidance

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -33,6 +33,23 @@ Before writing any code, read these files in order:
 
 ---
 
+## Spec Conflict Resolution
+
+When authoritative sources disagree, apply this priority order:
+
+1. **CLAUDE.md** — architecture, security, quality gates
+2. **`specs/standards/engineering.md`** — non-negotiable quality invariants
+3. **Feature spec** (`feat-XXX-spec.md`) — the contract for this feature
+4. **Existing codebase patterns** (`.claude/context/patterns.md`)
+
+**When a conflict is found:**
+
+- If the feature spec asks for something that violates CLAUDE.md → implement per CLAUDE.md, flag the deviation in the PR description.
+- If the feature spec defines a data model that conflicts with the existing schema → follow the existing schema, raise the discrepancy as a spec gap for the orchestrator.
+- If two spec files disagree on the same fact → apply the higher-layer spec (L1 > L2 > L3 > L4) per the hierarchy in `specs/README.md`. See `.claude/context/glossary.md` for the full layer definitions.
+
+---
+
 ## Your Task
 
 ### 1. Domain Layer

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -27,6 +27,25 @@ Before writing any code, read these files in order:
 
 ---
 
+## Spec Conflict Resolution
+
+When authoritative sources disagree, apply this priority order:
+
+1. **CLAUDE.md** — framework rules, coding standards
+2. **Feature spec** (`feat-XXX-spec.md`) — API contracts and functional requirements
+3. **Design spec** (`feat-XXX-design.md`) — layout, tokens, states
+4. **Brand spec** (`specs/standards/brand.md`) — design language
+
+**When a conflict is found:**
+
+- If the design spec contradicts brand.md token names → use brand.md token names, note the discrepancy in the PR description.
+- If the feature spec API contract differs from the actual backend implementation → implement to match the actual backend, raise a spec gap for the orchestrator.
+- If the design spec describes a UI state that the feature spec doesn't define → implement a safe default (e.g., empty state with a neutral message), document the assumption in the PR description.
+
+See `.claude/context/glossary.md` for canonical terminology and document hierarchy.
+
+---
+
 ## Your Task
 
 ### 1. Component Implementation

--- a/.claude/agents/spec-writer.md
+++ b/.claude/agents/spec-writer.md
@@ -28,6 +28,26 @@ Before starting, read these files in order:
 
 ---
 
+## Spec Conflict Resolution
+
+When authoritative sources disagree, apply this priority order:
+
+1. **CLAUDE.md** and **`specs/standards/engineering.md`** — non-negotiable architecture and security rules
+2. **L4 domain specs** (`specs/domain/*.md`) — existing business rules and invariants
+3. **Feature brief** — the WHAT (scope, user stories, acceptance criteria)
+4. **Research document** — codebase context and edge cases
+5. **Brand spec** (`specs/standards/brand.md`) — visual design decisions (for UI-facing features)
+
+**When a conflict is found:**
+
+- If the feature brief contradicts CLAUDE.md → implement per CLAUDE.md, note the conflict as a spec risk in the output under **Open Questions** or a dedicated **Spec Risks** section.
+- If the research document reveals codebase patterns that differ from spec-prescribed patterns → follow existing codebase patterns, document the pattern in `.claude/context/patterns.md`.
+- If two L4 domain specs disagree on the same fact → flag as blocking, do not invent a resolution. Surface the conflict to the orchestrator and list it as an open question.
+
+See `.claude/context/glossary.md` for canonical terminology and document hierarchy.
+
+---
+
 ## Your Task
 
 ### 1. User Stories & Acceptance Criteria

--- a/.claude/context/glossary.md
+++ b/.claude/context/glossary.md
@@ -1,0 +1,112 @@
+# Glossary — Canonical Terminology
+
+> Single source of truth for terms used across `.claude/agents/` files.
+
+---
+
+## Ralph Loop
+
+An autonomous iterate-until-done loop used by every agent:
+
+1. **Read** — load all required input files
+2. **Implement** — draft or build the deliverable
+3. **Validate** — run tests, linters, or cross-checks
+4. **Self-check** — verify all completion criteria are met
+5. **Repeat** — if any criterion fails, iterate; otherwise signal completion
+
+---
+
+## Document Hierarchy
+
+The MMF pipeline produces four document types per feature, in order:
+
+| Document | File pattern | Producer | Purpose |
+|----------|-------------|----------|---------|
+| Feature brief | `.claude/prds/feat-XXX-brief.md` | Product Strategist | Defines WHAT to build (scope, user stories, acceptance criteria) |
+| Research document | `.claude/prds/feat-XXX-research.md` | Spec Researcher | Codebase context, edge cases, domain knowledge |
+| Feature spec | `.claude/prds/feat-XXX-spec.md` | Spec Writer | Implementation-ready PRD (data model, API, domain, tests) |
+| Design spec | `.claude/prds/feat-XXX-design.md` | Design Speccer | Visual design (layout, tokens, states, responsive, a11y) |
+
+Use these names consistently. Avoid synonyms like "PRD" (too vague) or "spec" (ambiguous without qualifier).
+
+---
+
+## Naming Conventions
+
+### Application Service Files
+
+Canonical pattern: **`[use-case]-service.ts`** (e.g., `create-campaign-service.ts`)
+
+- Class name: `[UseCase]Service` (e.g., `CreateCampaignService`)
+- Lives in: `packages/backend/src/[context]/application/`
+
+Do not use `[Context]AppService` as a class name.
+
+### Port Files
+
+Canonical pattern: **`[resource]-repository.ts`** or **`[service]-port.ts`**
+
+- Prefix with the resource or external service name, not the bounded context name.
+- Examples: `campaign-repository.ts`, `payment-port.ts`, `email-port.ts`
+
+### Composition Root
+
+Canonical file: **`packages/backend/src/composition-root.ts`**
+
+Do not refer to this as "bootstrap" or "app.ts". The composition root wires all dependencies manually — no DI containers.
+
+---
+
+## Test Coverage Targets
+
+| Scope | Target | Enforcement |
+|-------|--------|-------------|
+| Domain layer (entities, VOs, domain services) | >= 90% unit test coverage | CI gate |
+| Overall project | >= 80% combined coverage | CI gate |
+| CI enforcement threshold | >= 90% on domain code | Blocks merge |
+
+When agents reference "test coverage", use the target for the specific scope, not a single blanket number.
+
+---
+
+## Tracking Files
+
+### `.claude/mock-status.md`
+
+Tracks which external services have mock adapters and their current state. If this file does not exist when an agent needs it, create it with this template:
+
+```markdown
+# Mock Status
+
+| Service | Mock Exists | Location | Notes |
+|---------|------------|----------|-------|
+| Stripe | yes/no | `packages/backend/src/.../mock/` | — |
+| Clerk | yes/no | — | — |
+| Veriff | yes/no | — | — |
+| AWS SES | yes/no | — | — |
+```
+
+### `.claude/manual-tasks.md`
+
+Tracks tasks that require human intervention (API keys, external config, infrastructure). If this file does not exist when an agent needs it, create it with this template:
+
+```markdown
+# Manual Tasks
+
+| # | Task | Feature | Status | Owner |
+|---|------|---------|--------|-------|
+| 1 | — | — | pending | — |
+```
+
+---
+
+## Spec Layer Hierarchy
+
+Specs follow a layered hierarchy defined in `specs/README.md`. When two specs conflict, the higher layer wins:
+
+- **L1** — Product vision and mission
+- **L2** — Standards (engineering, brand)
+- **L3** — Technical specs (architecture, security, frontend, data, audit)
+- **L4** — Domain specs (campaigns, payments, accounts, etc.)
+
+Higher layer number = more specific but lower authority on cross-cutting concerns.


### PR DESCRIPTION
## Summary

- Creates `.claude/context/glossary.md` — canonical definitions for Ralph Loop, document hierarchy, naming conventions (application services, port files, composition root), test coverage targets, tracking file templates, and spec layer hierarchy
- Adds a **Spec Conflict Resolution** section to `spec-writer.md`, `backend-engineer.md`, and `frontend-engineer.md` with prioritised source hierarchies and explicit conflict actions
- Each agent now knows what to do when a feature brief contradicts CLAUDE.md, a design spec contradicts brand.md, or two domain specs disagree

## Changes

| File | Change |
|------|--------|
| `.claude/context/glossary.md` | New — canonical terminology and templates |
| `.claude/agents/spec-writer.md` | New section after Inputs, before Your Task |
| `.claude/agents/backend-engineer.md` | New section after Inputs, before Your Task |
| `.claude/agents/frontend-engineer.md` | New section after Inputs, before Your Task |

## Test plan

- [x] `grep -r "Spec Conflict Resolution" .claude/agents/` returns exactly 3 files
- [x] `.claude/context/glossary.md` exists and covers all terms from issue #49
- [x] No agent templates were changed — only new sections added

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)