### PR TITLE
fix(autonomous): require classic PAT and deny gh pr merge

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,7 +100,7 @@
       "Bash(terraform validate:*)",
       "Bash(tflint:*)"
     ],
-    "deny": [],
+    "deny": ["Bash(gh pr merge:*)"],
     "ask": []
   },
   "hooks": {

--- a/autonomous/.env.agent.example
+++ b/autonomous/.env.agent.example
@@ -13,10 +13,11 @@ CLAUDE_CODE_OAUTH_TOKEN=
 ANTHROPIC_API_KEY=
 
 # --- GitHub (digital twin account) ------------------------------------------
+# Classic PAT with `repo` scope — required for branch push + PR creation.
+# Fine-grained PATs cannot create cross-fork PRs (GitHub limitation).
 
 GITHUB_TOKEN=ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 REPO_URL=https://github.com/LeeCampbell/MarsMissionFund
-UPSTREAM_REPO=LeeCampbell/MarsMissionFund
 BASE_BRANCH=main
 
 # --- Git identity (digital twin — NOT personal) ----------------------------

--- a/autonomous/README.md
+++ b/autonomous/README.md
@@ -3,12 +3,12 @@
 Isolated Docker environment for running Claude Code with `--dangerously-skip-permissions`.
 Container isolation replaces the permission model as the security boundary.
 
-The agent uses a **digital twin GitHub account** (not personal credentials) with reduced privileges — it can create branches and PRs but cannot merge.
+The agent uses a **digital twin GitHub account** (not personal credentials) with a classic PAT (`repo` scope). It can create branches and PRs but cannot merge (blocked by a deny rule in `.claude/settings.json`).
 
 ## Prerequisites
 
 - Docker and Docker Compose
-- A GitHub PAT for the digital twin account (scoped to `repo`)
+- A **classic** GitHub PAT for the digital twin account (scoped to `repo`) — fine-grained PATs cannot create cross-fork PRs
 - A Claude Code auth token (OAuth subscription or Anthropic API key)
 
 ## Quick Start
@@ -44,9 +44,10 @@ GitHub and git identity (use the digital twin account, never personal):
 
 | Variable | Description | Example |
 |---|---|---|
-| `GITHUB_TOKEN` | PAT for the digital twin account | `ghp_xxxx` |
+| `GITHUB_TOKEN` | Classic PAT for the digital twin account (`repo` scope) | `ghp_xxxx` |
 | `REPO_URL` | Repository to clone | `https://github.com/LeeCampbell/MarsMissionFund` |
 | `BASE_BRANCH` | Branch to clone and base work from | `main` |
+| `UPSTREAM_REPO` | *(optional)* Fork workflow: upstream `owner/repo` to sync main from | *(unset)* |
 | `GIT_AUTHOR_NAME` | Commit author name | `mmf-agent` |
 | `GIT_AUTHOR_EMAIL` | Commit author email | `mmf-agent@example.com` |
 | `GIT_COMMITTER_NAME` | Commit committer name | `mmf-agent` |


### PR DESCRIPTION
## Summary
- Require classic PAT (`repo` scope) for the autonomous agent — fine-grained PATs can't create cross-fork PRs ([GitHub limitation](https://github.com/orgs/community/discussions/131615))
- Remove `UPSTREAM_REPO` from `.env.agent.example` (not needed when cloning upstream directly with classic token)
- Add `gh pr merge` to settings.json deny list so the agent can propose PRs but never merge them

## Context
Diagnosed from a 1+ hour agent run where the agent completed feat-001 implementation and quality gates but couldn't create a PR due to token permissions. The agent pushed the branch successfully but `gh pr create` failed with `Resource not accessible by personal access token (createPullRequest)`.

## Test plan
- [ ] Rebuild agent container with new classic PAT in `.env.agent`
- [ ] Verify agent can push branches and create PRs
- [ ] Verify `gh pr merge` is blocked by deny rule

Generated with [Claude Code](https://claude.com/claude-code)